### PR TITLE
view画面にusername表示

### DIFF
--- a/app/views/microposts/_footer.html.erb
+++ b/app/views/microposts/_footer.html.erb
@@ -10,7 +10,7 @@
     <% end %>
   <% end %>
 <li>
-  by <%= link_to micropost.author.email, [micropost.author, :microposts] %>
+  by <%= link_to micropost.author.name, [micropost.author, :microposts] %>
 </li>
 <li>
   <%= micropost.created_at.strftime("%Y/%m/%d %H:%M") %>

--- a/app/views/microposts/edit.html.erb
+++ b/app/views/microposts/edit.html.erb
@@ -1,7 +1,11 @@
 <% @page_title = "ツイートの編集" %>
-<h1><%= @page_title %></h1>
+<h3><%= @page_title %></h3>
 
-<div class="toolbar"><%= link_to "ツイートの表示に戻る", @micropost %></div>
+<div class="toolbar">
+  <div class="text-center">
+    <%= link_to "ツイートの表示に戻る", @micropost, class: "btn btn-outline-primary btn-sm" %>
+  </div>
+</div>
 
 <%= form_for @micropost do |form| %>
   <%= render "form", form: form %>

--- a/app/views/microposts/index.html.erb
+++ b/app/views/microposts/index.html.erb
@@ -1,5 +1,5 @@
 <div class="micropostpage_title">
-  <% @page_title = @user ? @user.email + "さんのツイート" : "ツイートコーナー" %>
+  <% @page_title = @user ? @user.name + "さんのツイート" : "ツイートコーナー" %>
   <h4><%= @page_title %></h4>
 </div>
 

--- a/app/views/microposts/new.html.erb
+++ b/app/views/microposts/new.html.erb
@@ -1,5 +1,5 @@
 <% @page_title = "ツイートの新規作成" %>
-<h1><%= @page_title %></h1>
+<h3><%= @page_title %></h3>
 
 <%= form_for @micropost do |form| %>
   <%= render "form", form: form %>

--- a/app/views/microposts/show.html.erb
+++ b/app/views/microposts/show.html.erb
@@ -1,5 +1,5 @@
-<% @page_title = @micropost.author.email + "さんのツイート" %>
-<h5><%= @micropost.author.email %>さんのツイート</h5>
+<% @page_title = @micropost.author.name + "さんのツイート" %>
+<h5><%= @micropost.author.name %>さんのツイート</h5>
 <div class="micropostarea">
   <%= @micropost.content %>
     <% if @micropost.picture? %>

--- a/app/views/microposts/voted.html.erb
+++ b/app/views/microposts/voted.html.erb
@@ -1,5 +1,5 @@
 <% @page_title = "投票したツイート" %>
-<h1><%= @page_title %></h1>
+<h3><%= @page_title %></h3>
 
 <% if @microposts.present? %>
   <ul>


### PR DESCRIPTION
ツイッター各種画面表示を変更。emailの代わりにusernameを表示。